### PR TITLE
Fix a potential bug when controller processes before AR connected

### DIFF
--- a/lib/query_count/controller_runtime.rb
+++ b/lib/query_count/controller_runtime.rb
@@ -6,8 +6,8 @@ module QueryCount
     module ClassMethods
       def log_process_action(payload)
         messages    = super
-        count       = payload[:query_count]
-        count_cache = payload[:query_count_cache]
+        count       = payload[:query_count] || 0
+        count_cache = payload[:query_count_cache] || 0
 
         messages.push(
           "SQL Queries: #{count + count_cache}"\


### PR DESCRIPTION
There is a chance that controller process invoke before AR establish a connection, this can cause 
```
NoMethodError (undefined method `+' for nil:NilClass
``` 
while adding up 2 `nil` objects in `"SQL Queries: #{count + count_cache}"`.

Maybe we should just return the original messages if both `query_count` and `query_count_cache` was not set?